### PR TITLE
Add PageGym to the list of testing tools

### DIFF
--- a/m2/extensions/pagespeed/index.md
+++ b/m2/extensions/pagespeed/index.md
@@ -30,6 +30,7 @@ If you are running the website with a lot of images, scripts and content, the Pa
 **How to measure site grade?**
 
 *   [Google Page speed insights online tool](https://developers.google.com/speed/pagespeed/insights)
+*   [PageGym online tool](https://pagegym.com)
 *   [Gtmetrix online tool](http://gtmetrix.com)
 *   [Pingdom online tool](http://tools.pingdom.com)
 *   [Check GZIP compression](https://checkgzipcompression.com/)


### PR DESCRIPTION
Hi,

I just wanted to suggest adding another page speed testing tool to the list.

[Example report](https://pagegym.com/speed/test/docs-swissuplabs-com/mhoazarclm)

It's one of the most advanced out there, and it's specifically made to document and aid in the optimization process, so it's perfect for tuning the Pagespeed extension.